### PR TITLE
If Content-Encoding is removed, so should Transfer-Encoding

### DIFF
--- a/stardog_server.py
+++ b/stardog_server.py
@@ -116,7 +116,7 @@ class Proxy:
         cherrypy.response.status = api_resp.status_code
         
         for (header, header_value) in api_resp.headers.items():
-            if not ( header.lower() in ('content-length', 'server', 'content-encoding') ):
+            if not ( header.lower() in ('content-length', 'server', 'content-encoding', 'transfer-encoding') ):
                 cherrypy.response.headers[header] = header_value
 
         return api_resp.content


### PR DESCRIPTION
Because Transfer-Encoding header was left in on the reverse proxy (with the value `chunked`), the browser was trying to interpret the lead bytes of the response as chunk size, which was no good in some cases and generally caused issues...whoopsie